### PR TITLE
chore(schemas): add toJSON transform to message and conversation schemas

### DIFF
--- a/src/schemas/conversation.schema.ts
+++ b/src/schemas/conversation.schema.ts
@@ -16,3 +16,12 @@ export class Сonversation {
 }
 
 export const СonversationSchema = SchemaFactory.createForClass(Сonversation);
+
+СonversationSchema.set('toJSON', {
+  virtuals: true,
+  versionKey: false,
+  transform: function (doc, ret) {
+    ret.id = ret._id;
+    delete ret._id;
+  },
+});

--- a/src/schemas/message.schema.ts
+++ b/src/schemas/message.schema.ts
@@ -22,3 +22,12 @@ export class Message {
 }
 
 export const MessageSchema = SchemaFactory.createForClass(Message);
+
+MessageSchema.set('toJSON', {
+  virtuals: true,
+  versionKey: false,
+  transform: function (doc, ret) {
+    ret.id = ret._id;
+    delete ret._id;
+  },
+});


### PR DESCRIPTION
Add toJSON transform to both MessageSchema and ConversationSchema to ensure consistent JSON output by renaming `_id` to `id` and removing the version key. This improves API response consistency and simplifies client-side handling.